### PR TITLE
Refactor length check in Find function

### DIFF
--- a/find.go
+++ b/find.go
@@ -17,7 +17,7 @@ func Find(a string, l int) (int, error) {
 	if l <= 3 {
 		return 0, fmt.Errorf("l must be greater than 3")
 	}
-	if len(a) == 0 || len(a) <= l {
+	if len(a) <= l {
 		return 0, fmt.Errorf("invalid length")
 	}
 	for i := l - 1; i >= l-4; i-- {


### PR DESCRIPTION
This pull request includes a change in the `find.go` file to simplify the condition checking in the `Find` function. The condition `len(a) == 0` was removed because it is redundant; the condition `len(a) <= l` already covers the case where the length of `a` is 0.