### PR TITLE
Update Go version to 1.22.2 in workflows and go.mod files

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.21.x' ]
+        go: [ '1.22.x' ]
     steps:
 
     - name: Set up Go

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,5 +16,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-           go-version-input: 1.21.4
+           go-version-input: 1.22.2
            go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/catatsuy/u8p
 
-go 1.21.5
+go 1.22.2


### PR DESCRIPTION
This pull request primarily focuses on updating the Go version used across various workflow files and the project module. The changes include updating the Go version in `.github/workflows/go.yml` and `.github/workflows/security.yml` files, and in the `go.mod` file.

Here are the key changes:

Go version updates:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL10-R10): Updated the Go version in the `jobs:` section from `1.21.x` to `1.22.x`.
* [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL19-R19): Changed the `go-version-input:` from `1.21.4` to `1.22.2` in the `jobs:` section.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.21.5` to `1.22.2`.

These changes ensure that the project is using the latest stable version of Go, which can bring performance improvements, bug fixes, and new features.