### PR TITLE
Optimize UTF-8 validation using utf8.RuneStart function

### DIFF
--- a/find.go
+++ b/find.go
@@ -1,13 +1,8 @@
 package u8p
 
-import "fmt"
-
-const (
-	t1 = 0b00000000
-	tx = 0b10000000
-	t2 = 0b00000110
-	t3 = 0b00001110
-	t4 = 0b00011110
+import (
+	"fmt"
+	"unicode/utf8"
 )
 
 func Find(a string, l int) (int, error) {
@@ -21,28 +16,9 @@ func Find(a string, l int) (int, error) {
 		return 0, fmt.Errorf("invalid length")
 	}
 	for i := l - 1; i >= l-4; i-- {
-		if isUTF8LeadByte(a[i]) {
+		if utf8.RuneStart(a[i]) {
 			return i, nil
 		}
 	}
 	return 0, fmt.Errorf("invalid utf8")
-}
-
-func isUTF8LeadByte(tmp byte) bool {
-	if tmp&tx == t1 {
-		return true
-	}
-	tmp >>= 3
-	if tmp == t4 {
-		return true
-	}
-	tmp >>= 1
-	if tmp == t3 {
-		return true
-	}
-	tmp >>= 1
-	if tmp == t2 {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
This pull request primarily focuses on refactoring the `find.go` file in the `u8p` package. The changes include updating the import statements, replacing a custom function for checking UTF8 lead bytes with a built-in function, and removing the now redundant custom function.

Here are the key changes:

* [`find.go`](diffhunk://#diff-18adfe59f2074ab8128f5be89c95633c611aaf2cc76d9a20282c65c68878efbdL3-R5): The import statements were updated to include the `unicode/utf8` package, which provides built-in functions for working with UTF8 encoded strings. This change simplifies the code by using standard library functions instead of custom ones.
* `func Find(a string, l int) (int, error)`: The custom `isUTF8LeadByte` function was replaced with the built-in `utf8.RuneStart` function. This change improves code readability and maintainability by using a standard function with a clear purpose.
* [`func isUTF8LeadByte(tmp byte) bool`](diffhunk://#diff-18adfe59f2074ab8128f5be89c95633c611aaf2cc76d9a20282c65c68878efbdL24-L48): This custom function was removed entirely as it was replaced by the built-in `utf8.RuneStart` function. This further simplifies the codebase and reduces potential points of failure.